### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "umm:init": "umm-init",
     "umm:generate_assembly_definition": "umm-generate_assembly_definition",
     "umm:module:install": "umm-module-install",
-    "umm:module:uninstall": "umm-module-uninstall"
+    "umm:module:uninstall": "umm-module-uninstall",
+    "postinstall": "npm run --silent umm:module:install",
+    "postuninstall": "npm run --silent umm:module:uninstall"
   },
   "author": {
     "name": "baba-s",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "Assets"
   ],
   "dependencies": {
-    "@umm/scripts": "github:umm/scripts#^1.0.0"
+    "@umm/scripts": "umm/scripts#^1.0.0"
   },
   "devDependencies": {},
   "version": "1.0.1"


### PR DESCRIPTION
## 💀 問題

```diff
-"@umm/scripts@umm/scripts#^1.0.0":
+"@umm/scripts@github:umm/scripts#^1.0.0", "@umm/scripts@umm/scripts#^1.0.0":
```

* `uni_debug_menu` をインストールしたところ、`yarn.lock` で上記のような差分が出た
    * 依存している umm のパスの記載が間違っている？
* `yarn install` してみたところ、`Assets/Modules` 配下に `uni_debug_menu` のディレクトリがコピーされない

## 😎 やったこと
* [x] 依存している umm のパスの記載を修正する
* [x] `Assets/Modules` 配下にコピーされるようスクリプトを追記する
